### PR TITLE
Upgrade Avro to 1.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,10 @@ targetCompatibility = 1.8
 dependencies {
     compile  "org.embulk:embulk-core:0.9.4"
     provided "org.embulk:embulk-core:0.9.4"
-    compile "org.apache.avro:avro:1.8.2"
+    compile "org.apache.avro:avro:1.10.1"
+    compile "com.github.luben:zstd-jni:1.4.5-12"
+    compile "org.tukaani:xz:1.8"
+    compile "org.xerial.snappy:snappy-java:1.1.8.1"
     testCompile "junit:junit:4.+"
 
     testCompile  "org.embulk:embulk-core:0.9.4:tests"


### PR DESCRIPTION
[Recent versions of Avro support zstd compression](https://issues.apache.org/jira/browse/AVRO-2195), but currently embulk-parser-avro doesn't.

```
$ mkdir /tmp/input
$ curl -sLO https://downloads.apache.org/avro/avro-1.10.1/java/avro-tools-1.10.1.jar
$ java -jar avro-tools-1.10.1.jar random --schema-file src/test/resources/org/embulk/parser/avro/item.avsc --count 1 --codec zstandard /tmp/input/items.avro
$ cat /tmp/config.yml 
in:
  type: file
  path_prefix: /tmp/input/items.avro
  parser:
    charset: UTF-8
    newline: LF
    type: avro
    avsc: src/test/resources/org/embulk/parser/avro/item.avsc
    columns:
    - {name: id, type: long}
    - {name: code, type: long}
    - {name: name, type: string}
    - {name: description, type: string}
    - {name: flag, type: boolean}
    - {name: created_at, type: string}
    - {name: created_at_utc, type: double}
    - {name: price, type: double}
    - {name: spec, type: json}
    - {name: tags, type: json}
    - {name: options, type: json}
    - {name: item_type, type: string}
    - {name: dummy, type: string}
out: {type: stdout}
$ embulk run /tmp/config.yml 

(snip)

Error: org.apache.avro.AvroRuntimeException: Unrecognized codec: zstandard
```

Would it be possible to support that codec with this PR?